### PR TITLE
Update requirements.txt for Odoo Version 11 to 16

### DIFF
--- a/odoo_tools/requirements/requirements-11.0.txt
+++ b/odoo_tools/requirements/requirements-11.0.txt
@@ -1,44 +1,50 @@
-setuptools<58
 Babel==2.3.4
 decorator==4.0.10
 docutils==0.12
 ebaysdk==2.1.5
+feedparser==5.2.1
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version >= '3.7'
-greenlet>=0.4.10
+greenlet==0.4.10 ; python_version < '3.7'
+greenlet==0.4.14 ; python_version >= '3.7'
 html2text==2016.9.19
 Jinja2==2.10.1
-lxml>=3.7.1
+lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
+lxml==4.2.3 ; sys_platform != 'win32' and python_version >= '3.7'
+lxml ; sys_platform == 'win32'
 Mako==1.0.4
 MarkupSafe==0.23
 mock==2.0.0
 num2words==0.5.6
 ofxparse==0.16
 passlib==1.6.5
-Pillow>=4.0.0
+Pillow==4.0.0 ; python_version < '3.7'
+Pillow==6.1.0 ; python_version >= '3.7'
 psutil==4.3.1; sys_platform != 'win32'
 psutil==5.6.3; sys_platform == 'win32'
-psycopg2>=2.7.3.1
+psycopg2==2.7.3.1; sys_platform != 'win32'
+psycopg2==2.8.3; sys_platform == 'win32'
 pydot==1.2.3
 pyldap==2.4.28; sys_platform != 'win32'
 pyparsing==2.1.10
 PyPDF2==1.26.0
 pyserial==3.1.1
 python-dateutil==2.5.3
+# vatnumber requirement. Last version compatible
 python-stdnum<=1.14
 pytz==2016.7
 pyusb==1.0.0
 PyYAML==3.12 ; python_version < '3.7'
 PyYAML==3.13 ; python_version >= '3.7'
 qrcode==5.3
-Pillow>=4
-reportlab>=3.5.59
+reportlab==3.3.0
 requests==2.20.0
 suds-jurko==0.6
 vatnumber==1.2
 vobject==0.9.3
-Werkzeug>=0.11.15, <1.0
+Werkzeug==0.11.15 ; sys_platform != 'win32'
+Werkzeug==0.16.0  ; sys_platform == 'win32'
 XlsxWriter==0.9.3
 xlwt==1.3.*
-xlrd>=1.0.0, <=1.2.0
+xlrd==1.0.0
 pypiwin32 ; sys_platform == 'win32'

--- a/odoo_tools/requirements/requirements-12.0.txt
+++ b/odoo_tools/requirements/requirements-12.0.txt
@@ -1,29 +1,30 @@
-setuptools<58
 Babel==2.3.4
-setuptools<58
 chardet==3.0.4
 decorator==4.0.10
 docutils==0.12
 ebaysdk==2.1.5
-gevent>=1.1.2, <1.5.0 ; python_version < '3.7'
-greenlet>=0.4.10; python_version < '3.7'
-gevent>=20.9; python_version >= '3.7'
-greenlet>=0.4.17; python_version >= '3.7'
+gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
+gevent==1.5.0 ; python_version >= '3.7'
+greenlet==0.4.10 ; python_version < '3.7'
+greenlet==0.4.14 ; python_version >= '3.7'
 html2text==2016.9.19
 Jinja2==2.10.1
 libsass==0.12.3
-lxml>=3.7.1
+lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
+lxml==4.2.3 ; sys_platform != 'win32' and python_version >= '3.7'
+lxml ; sys_platform == 'win32'
 Mako==1.0.4
 MarkupSafe==0.23
 mock==2.0.0
 num2words==0.5.6
 ofxparse==0.16
 passlib==1.6.5
-Pillow>=5.4.1
+Pillow==4.0.0 ; python_version < '3.7'
+Pillow==6.1.0 ; python_version >= '3.7'
 psutil==4.3.1; sys_platform != 'win32'
 psutil==5.6.3; sys_platform == 'win32'
-psycopg2==2.8.5; sys_platform == 'win32'
-psycopg2 >=2.7.7, <=2.8.6; sys_platform != 'win32'
+psycopg2==2.7.3.1; sys_platform != 'win32' and python_version < '3.8'
+psycopg2==2.8.3; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.2.3
 pyldap==2.4.28; sys_platform != 'win32'
 pyparsing==2.1.10
@@ -33,13 +34,14 @@ python-dateutil==2.5.3
 pytz==2016.7
 pyusb==1.0.0
 qrcode==5.3
-reportlab>=3.5.59
+reportlab==3.3.0
 requests==2.20.0
 suds-jurko==0.6
 vatnumber==1.2
 vobject==0.9.3
-Werkzeug>=0.11.15, <1.0
+Werkzeug==0.11.15 ; sys_platform != 'win32'
+Werkzeug==0.16.0  ; sys_platform == 'win32'
 XlsxWriter==0.9.3
 xlwt==1.3.*
-xlrd >=1.0.0, <=1.2.0
+xlrd==1.0.0
 pypiwin32 ; sys_platform == 'win32'

--- a/odoo_tools/requirements/requirements-13.0.txt
+++ b/odoo_tools/requirements/requirements-13.0.txt
@@ -1,30 +1,32 @@
-setuptools<58
 Babel==2.6.0
 chardet==3.0.4
 decorator==4.3.0
-docutils>=0.14
+docutils==0.14
 ebaysdk==2.1.5
 gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
-gevent==1.5.0 ; python_version == '3.7'
-gevent>=20.9.0 ; python_version >= '3.8'
-greenlet>=0.4.10
-html2text==2018.1.9
+gevent==1.5.0 ; python_version >= '3.7'
+gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
+greenlet==0.4.10 ; python_version < '3.7'
+greenlet==0.4.15 ; python_version >= '3.7'
 Jinja2==2.10.1
 libsass==0.17.0
-lxml>=3.7.1
+lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
+lxml==4.3.2 ; sys_platform != 'win32' and python_version >= '3.7'
+lxml ; sys_platform == 'win32'
 Mako==1.0.7
 MarkupSafe==1.1.0
 mock==2.0.0
 num2words==0.5.6
 ofxparse==0.19
 passlib==1.7.1
-Pillow>=5.4.1
+Pillow==5.4.1 ; python_version < '3.7' or sys_platform != 'win32'
+Pillow==6.1.0 ; sys_platform == 'win32' and python_version >= '3.7'
 polib==1.1.0
 psutil==5.6.6
-psycopg2==2.8.5; sys_platform == 'win32'
-psycopg2 >=2.7.7, <=2.8.6; sys_platform != 'win32'
+psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
+psycopg2==2.8.3; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
-python-ldap >=3.1.0, <= 3.4.0; sys_platform != 'win32'
+python-ldap==3.1.0; sys_platform != 'win32'
 pyparsing==2.2.0
 PyPDF2==1.26.0
 pyserial==3.4
@@ -32,13 +34,14 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.59
-requests>=2.21.0
+reportlab==3.5.13
+requests==2.21.0
 zeep==3.2.0
 vatnumber==1.2
 vobject==0.9.6.1
-Werkzeug<1.0
+Werkzeug==0.14.1 ; sys_platform != 'win32'
+Werkzeug==0.16.0 ; sys_platform == 'win32'
 XlsxWriter==1.1.2
 xlwt==1.3.*
-xlrd >=1.1.0, <=1.2.0
+xlrd==1.1.0
 pypiwin32 ; sys_platform == 'win32'

--- a/odoo_tools/requirements/requirements-14.0.txt
+++ b/odoo_tools/requirements/requirements-14.0.txt
@@ -5,26 +5,34 @@ docutils==0.14
 ebaysdk==2.1.5
 freezegun==0.3.11; python_version < '3.8'
 freezegun==0.3.15; python_version >= '3.8'
+gevent==1.1.2 ; sys_platform != 'win32' and python_version < '3.7'
 gevent==1.5.0 ; python_version == '3.7'
 gevent==20.9.0 ; python_version >= '3.8'
-greenlet>=0.4.10
-html2text==2018.1.9
+gevent==1.4.0 ; sys_platform == 'win32' and python_version < '3.7'
+greenlet==0.4.10 ; python_version < '3.7'
+greenlet==0.4.15 ; python_version == '3.7'
+greenlet==0.4.17 ; python_version > '3.7'
 idna==2.6
 Jinja2==2.10.1; python_version < '3.8'
 # bullseye version, focal patched 2.10
 Jinja2==2.11.2; python_version >= '3.8'
 libsass==0.17.0
-lxml >=3.7.1
+lxml==3.7.1 ; sys_platform != 'win32' and python_version < '3.7'
+lxml==4.3.2 ; sys_platform != 'win32' and python_version == '3.7'
+lxml==4.6.1 ; sys_platform != 'win32' and python_version > '3.7'
+lxml ; sys_platform == 'win32'
 Mako==1.0.7
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
 passlib==1.7.1
-Pillow >= 5.4.1
+Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
+Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'
+Pillow==8.1.1 ; python_version > '3.7'
 polib==1.1.0
 psutil==5.6.6
-psycopg2==2.8.5; sys_platform == 'win32'
-psycopg2 >=2.7.7, <=2.8.6; sys_platform != 'win32'
+psycopg2==2.7.7; sys_platform != 'win32' and python_version < '3.8'
+psycopg2==2.8.5; sys_platform == 'win32' or python_version >= '3.8'
 pydot==1.4.1
 python-ldap==3.1.0; sys_platform != 'win32'
 PyPDF2==1.26.0
@@ -33,14 +41,15 @@ python-dateutil==2.7.3
 pytz==2019.1
 pyusb==1.0.2
 qrcode==6.1
-reportlab>=3.5.59
+reportlab==3.5.13; python_version < '3.8'
+reportlab==3.5.55; python_version >= '3.8'
 requests==2.21.0
 zeep==3.2.0
 python-stdnum==1.8
 vobject==0.9.6.1
-Werkzeug >=0.14.1, <1.0
+Werkzeug==0.16.1
 XlsxWriter==1.1.2
 xlwt==1.3.*
-xlrd >=1.0.0, <=1.2.0
+xlrd==1.1.0; python_version < '3.8'
+xlrd==1.2.0; python_version >= '3.8'
 pypiwin32 ; sys_platform == 'win32'
-setuptools<58

--- a/odoo_tools/requirements/requirements-16.0.txt
+++ b/odoo_tools/requirements/requirements-16.0.txt
@@ -1,6 +1,6 @@
 Babel==2.9.1  # min version = 2.6.0 (Focal with security backports)
 chardet==3.0.4
-cryptography==2.6.1  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
+cryptography==3.4.8
 decorator==4.4.2
 docutils==0.16
 ebaysdk==2.1.5


### PR DESCRIPTION
Copied [requirements.txt](https://github.com/odoo/odoo/blob/15.0/requirements.txt) from several odoo versions (from 11 to 16)