### PR TITLE
Release 0.1.4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        odoo-version: ["13", "14", "15"]
+        odoo-version: ["13", "14", "15", "16"]
         exclude:
           - odoo-version: "14"
             python-version: "3.10"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -82,7 +82,9 @@ jobs:
         PGPASSWORD: postgres
         PGPORT: 5432
       run: |
-        TEST_ODOO=${{ matrix.odoo-version }} pytest --cov=./ --cov-config=./setup.cfg -v
+        pytest --cov=./ --cov-config=./setup.cfg -v
+        TEST_ODOO=${{ matrix.odoo-version }} pytest --cov=./ --cov-config=./setup.cfg --cov-append -v tests/test_odoo_git.py
+        TEST_ODOO=${{ matrix.odoo-version }} pytest --cov=./ --cov-config=./setup.cfg --cov-append -v tests/test_odoo_release.py
         codecov
 
     - name: Install Odoo

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,17 +7,27 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "release-**"
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        odoo-version: ["13", "14", "15", "16"]
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+        odoo-version:
+          - "13"
+          - "14"
+          - "15"
+          - "16"
         exclude:
           - odoo-version: "14"
             python-version: "3.10"
@@ -43,22 +53,28 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install postgres client
+
+    - name: Install Native Libraries
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential python3-dev postgresql-client libldap2-dev libsasl2-dev python3-psycopg2 python3-wheel python3-gevent
-    - name: Install dependencies
+        sudo apt-get install -y --no-install-recommends postgresql-client git curl build-essential libxml2-dev libsasl2-dev libsass-dev libldap2-dev libjpeg-dev
+        # python3-lxml python3-pip python3-psycopg2 python3-ldap python3-libsass python3-lxml python3-pillow python3-pypdf2 python3-psutil python3-asn1crypto
+
+    - name: Install Test Dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest codecov
         python -m pip install -e ".[test]"
+        python -m pip install "python-ldap>=3.2" "libsass<=0.21,>=0.18" "lxml>=4.5.0" "Pillow>=7.0" "PyPDF2>=1.26" "psutil>=5.5.1"
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test with pytest
       env:
         PGHOST: localhost

--- a/conftest.py
+++ b/conftest.py
@@ -5,4 +5,5 @@ from tests.fixtures import (
     odoo_env,
     change_test_dir,
     ignore_warnings,
+    runner
 )

--- a/odoo_tools/api/environment.py
+++ b/odoo_tools/api/environment.py
@@ -1,5 +1,6 @@
 import os
 import toml
+import json
 import logging
 from pathlib import Path
 from contextlib import contextmanager
@@ -15,6 +16,7 @@ from ..utils import (
     ConfigParser
 )
 from ..utilities.config import get_env_params, parse_value, get_defaults
+from ..utilities.loaders import FileLoader
 from ..configuration.misc import (
     get_resource
 )
@@ -22,6 +24,7 @@ from ..configuration.misc import (
 from .context import Context
 from .management import ManagementApi
 from .modules import ModuleApi
+from .services import ServiceApi
 
 
 _logger = logging.getLogger(__name__)
@@ -71,8 +74,18 @@ class Environment(object):
         self.context = context
         self.modules = ModuleApi(self)
         self.manage = ManagementApi(self)
+        self.services = ServiceApi(self)
+
         self._config = ConfigParser()
         self._nested = False
+        self._read_config = False
+        self.loader = FileLoader()
+
+        self._prepare_parser()
+
+    def _prepare_parser(self):
+        self.loader.parsers['.toml'] = lambda data: toml.loads(data)
+        self.loader.parsers['.json'] = lambda data: json.loads(data)
 
     def path(self):
         """
@@ -163,8 +176,9 @@ class Environment(object):
             self._nested = True
             is_top = True
 
-        if not nested and config_path.exists():
+        if not nested and config_path.exists() and not self._read_config:
             try:
+                self._read_config = True
                 self._config.read(str(config_path))
             except Exception:
                 _logger.info("Couldn't read ODOO_RC file.", exc_info=True)

--- a/odoo_tools/api/management.py
+++ b/odoo_tools/api/management.py
@@ -402,3 +402,31 @@ class ManagementApi(object):
             )
 
         return package_list
+
+    def native_packages(self):
+        python_packages = [
+            "python3-pip",
+            "python3-psycopg2",
+            "python3-ldap",
+            "python3-libsass",
+            "python3-lxml",
+            "python3-pillow",
+            "python3-pypdf2",
+            "python3-psutil",
+            "python3-asn1crypto",
+            # "python3-reportlab", Not needed package badly get installed
+            # "python3-renderpm",
+        ]
+
+        base_packages = [
+            "git",
+            "curl",
+        ]
+
+        distrib = {
+            "default": base_packages + python_packages,
+            "ubuntu": base_packages + python_packages,
+            "debian": base_packages + python_packages
+        }
+
+        return distrib['ubuntu']

--- a/odoo_tools/api/management.py
+++ b/odoo_tools/api/management.py
@@ -1,3 +1,4 @@
+import distro
 import six
 import logging
 import psycopg2
@@ -318,10 +319,7 @@ class ManagementApi(object):
 
         .. _NIGHTLY: https://nightly.odoo.com/
         """
-        if hasattr(opts, 'cache'):
-            cache = opts.cache
-        else:
-            cache = None
+        cache = opts.cache
 
         if release:
             installer = OfficialRelease(
@@ -403,7 +401,7 @@ class ManagementApi(object):
 
         return package_list
 
-    def native_packages(self):
+    def native_packages(self, distrib_override=None):
         python_packages = [
             "python3-pip",
             "python3-psycopg2",
@@ -423,10 +421,19 @@ class ManagementApi(object):
             "curl",
         ]
 
-        distrib = {
-            "default": base_packages + python_packages,
+        distrib_map = {
+            "default": base_packages,
             "ubuntu": base_packages + python_packages,
+            "fedora": base_packages + python_packages,
             "debian": base_packages + python_packages
         }
 
-        return distrib['ubuntu']
+        if distrib_override is not None:
+            distrib_id = distro.id()
+        else:
+            distrib_id = distrib_override
+
+        if distrib_id in distrib_map:
+            return distrib_map[distrib_id]
+        else:
+            return distrib_map['default']

--- a/odoo_tools/api/objects.py
+++ b/odoo_tools/api/objects.py
@@ -1,3 +1,4 @@
+import hashlib
 from six import ensure_text
 import shutil
 import logging
@@ -549,6 +550,20 @@ class Manifest(object):
         """
         if self.path.exists():
             shutil.rmtree(self.path, ignore_errors=True)
+
+    def checksum(self):
+        """
+        Computes the checksum of the module itself.
+        This can later be used to check if the module has changed
+        and force an update of the module as the version that
+        is installed doesn't match the one on the filesystem.
+        """
+        check = hashlib.sha1()
+
+        for file in self.files():
+            check.update(file.open('rb').read())
+
+        return check
 
     def files(self):
         """

--- a/odoo_tools/api/objects.py
+++ b/odoo_tools/api/objects.py
@@ -574,12 +574,16 @@ class Manifest(object):
         considered as "sources". It will also yield files located in
         the static folder.
         """
-        for file in self.path.glob('**/*'):
-            if file.is_dir():
-                continue
-            if file.name.endswith('.pyc'):
-                continue
+        all_files = [
+            file
+            for file in self.path.glob('**/*')
+            if not file.is_dir()
+            if not file.name.endswith('.pyc')
+        ]
 
+        all_files.sort()
+
+        for file in all_files:
             yield file
 
     def package(self):

--- a/odoo_tools/api/services.py
+++ b/odoo_tools/api/services.py
@@ -1,0 +1,98 @@
+from zipfile import ZipFile
+import giturlparse
+import logging
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from ..configuration.git import fetch_addons, checkout_repo
+from ..services.objects import ServiceManifests
+from ..modules.search import find_modules_paths
+
+
+_logger = logging.getLogger(__name__)
+
+
+class ServiceApi(object):
+
+    def __init__(self, env, cache=None):
+        self.environment = env
+        self.cache_path = cache
+
+    def get_services(self, lookup_path):
+        lookup_path = Path(lookup_path)
+
+        if lookup_path.exists():
+            services_path = lookup_path
+
+        data = self.environment.loader.load_file(services_path)
+        return ServiceManifests.parse(data)
+
+    def checkout(
+        self,
+        service,
+        target_path,
+        fetch_path=None,
+        decrypt_key=None
+    ):
+        if not fetch_path:
+            fetch_path = target_path
+
+        results = []
+
+        for key, addon in service.addons.items():
+            if not giturlparse.parse(addon.url).valid:
+                _logger.info(
+                    "Skipping addon %s as it has an invalid url.", addon.url
+                )
+                continue
+
+            checkout_path = Path.cwd() / target_path / addon.repo_path
+
+            path, info = fetch_addons(
+                addon,
+                fetch_path,
+                decrypt_key=decrypt_key
+            )
+
+            if fetch_path != checkout_path:
+                checkout_repo(path, checkout_path)
+
+            results.append(info)
+
+        return results
+
+    def package(
+        self,
+        service,
+        output_path,
+        fetch_path=None,
+        decrypt_key=None
+    ):
+        with TemporaryDirectory() as tempdir:
+            target = Path(tempdir)
+
+            self.checkout(
+                service,
+                target,
+                fetch_path,
+                decrypt_key
+            )
+
+            zipfile = ZipFile(str(output_path), 'w')
+
+            # TODO copy modules and requirements.txt file and skip the rest
+            for file in target.rglob("*"):
+                if '.git' in file.parts:
+                    continue
+
+                if '.github' in file.parts:
+                    continue
+
+                if not file.is_file():
+                    continue
+
+                zip_filename = file.relative_to(target)
+
+                with file.open('rb') as fin:
+                    with zipfile.open(str(zip_filename), mode='w') as fout:
+                        fout.write(fin.read())

--- a/odoo_tools/api/services.py
+++ b/odoo_tools/api/services.py
@@ -66,9 +66,10 @@ class ServiceApi(object):
         service,
         output_path,
         fetch_path=None,
-        decrypt_key=None
+        decrypt_key=None,
+        temp_dir_manager=TemporaryDirectory
     ):
-        with TemporaryDirectory() as tempdir:
+        with temp_dir_manager() as tempdir:
             target = Path(tempdir)
 
             self.checkout(

--- a/odoo_tools/cli/click/gen.py
+++ b/odoo_tools/cli/click/gen.py
@@ -1,0 +1,10 @@
+import click
+import logging
+
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group()
+def gen():
+    pass

--- a/odoo_tools/cli/click/gen.py
+++ b/odoo_tools/cli/click/gen.py
@@ -8,3 +8,8 @@ _logger = logging.getLogger(__name__)
 @click.group()
 def gen():
     pass
+
+
+@gen.command()
+def info():
+    print("Install more modules like odoo-tools-rest")

--- a/odoo_tools/cli/click/manage.py
+++ b/odoo_tools/cli/click/manage.py
@@ -176,19 +176,10 @@ def setup(
 
     opts = DictObject()
 
-    if not languages:
-        opts.languages = "all"
-    else:
-        opts.languages = languages
-
-    if upgrade:
-        opts.upgrade = True
-
-    if target:
-        opts.target = Path.cwd() / target
-
-    if cache:
-        opts.cache = Path.cwd() / cache
+    opts.languages = languages if languages else "all"
+    opts.upgrade = True if upgrade else False
+    opts.target = Path.cwd() / target if target else None
+    opts.cache = Path.cwd() / cache if cache else None
 
     env.manage.install_odoo(
         version,

--- a/odoo_tools/cli/click/services.py
+++ b/odoo_tools/cli/click/services.py
@@ -33,9 +33,9 @@ def service():
 @click.argument('env')
 @click.pass_context
 def show(ctx, service_file, env, url):
-    env = ctx.obj['env']
+    oenv = ctx.obj['env']
 
-    manifests = env.services.get_services(service_file)
+    manifests = oenv.services.get_services(service_file)
 
     service = manifests.services.get(env)
     resolved_service = service.resolved

--- a/odoo_tools/cli/odot.py
+++ b/odoo_tools/cli/odot.py
@@ -2,17 +2,7 @@ import click
 import logging
 
 from ..odoo import Environment
-
-from .click.module import module
-from .click.path import addons_paths
-from .click.config import config
-from .click.entrypoint import entrypoint
-from .click.shell import shell
-from .click.manage import manage
-from .click.services import service
-from .click.platform import platform
-from .click.users import user
-from .click.db import db
+from .registry import registry
 
 
 @click.group()
@@ -45,13 +35,5 @@ def command(ctx, config, log_level, exclude_odoo):
         logging.basicConfig(level=log_level)
 
 
-command.add_command(config)
-command.add_command(addons_paths)
-command.add_command(module)
-command.add_command(entrypoint)
-command.add_command(shell)
-command.add_command(manage)
-command.add_command(service)
-command.add_command(platform)
-command.add_command(user)
-command.add_command(db)
+registry.set_main(command)
+registry.load()

--- a/odoo_tools/cli/registry.py
+++ b/odoo_tools/cli/registry.py
@@ -1,0 +1,37 @@
+from pkg_resources import iter_entry_points
+
+
+class CommandRegistry(object):
+    def __init__(self):
+        self.groups = {}
+        self.main_command = None
+        self.loaded = set()
+
+    def set_main(self, command):
+        self.main_command = command
+
+    def get(self, name):
+        return self.groups[name]
+
+    def register(self, name, command):
+        self.groups[name] = command
+
+    def register_commands(self):
+        for ep in iter_entry_points(group='odootools.command'):
+            registry.register(ep.name, ep.load())
+
+        for ep in iter_entry_points(group='odootools.command.ext'):
+            command = self.groups[ep.name]
+            obj = ep.load()
+            command.add_command(obj)
+
+    def load(self):
+        for key, value in self.groups.items():
+            if key in self.loaded:
+                continue
+            self.loaded.add(key)
+            self.main_command.add_command(value)
+
+
+registry = CommandRegistry()
+registry.register_commands()

--- a/odoo_tools/cli/registry.py
+++ b/odoo_tools/cli/registry.py
@@ -18,7 +18,7 @@ class CommandRegistry(object):
 
     def register_commands(self):
         for ep in iter_entry_points(group='odootools.command'):
-            registry.register(ep.name, ep.load())
+            self.register(ep.name, ep.load())
 
         for ep in iter_entry_points(group='odootools.command.ext'):
             command = self.groups[ep.name]

--- a/odoo_tools/configuration/odoo.py
+++ b/odoo_tools/configuration/odoo.py
@@ -11,6 +11,7 @@ from six import ensure_binary, ensure_str
 import logging
 import requests
 from packaging.version import parse as version_parse
+from .pip import pip_command
 
 _logger = logging.getLogger(__name__)
 
@@ -129,25 +130,22 @@ class OdooSource(object):
 
         _logger.info("Installing odoo")
 
-        args = [
-            sys.executable,
-            '-m',
-            'pip',
-            'install'
-        ]
+        target = (
+            self.options.target
+            if hasattr(self.options, 'target') and self.options.target
+            else None
+        )
 
-        if hasattr(self.options, 'upgrade') and self.options.upgrade:
-            args.append('-U')
+        upgrade = (
+            self.options.upgrade
+            if hasattr(self.options, 'upgrade') and self.options.upgrade
+            else False
+        )
 
-        if hasattr(self.options, 'target') and self.options.target:
-            args += [
-                "--target", str(self.options.target),
-                "--implementation", "cp",
-                "--python", "3.8",
-                # "--only-binary", ":all:"
-                "--no-deps",
-            ]
+        args = pip_command(target=target, upgrade=upgrade)
 
+        # Ensure setuptools less than 58 is installed for odoo
+        # versions from 11 to 13.
         if (
             self.parsed_version.major > 10 and
             self.parsed_version.major < 14

--- a/odoo_tools/configuration/odoo.py
+++ b/odoo_tools/configuration/odoo.py
@@ -121,26 +121,14 @@ class OdooSource(object):
             self.installed_release
         )
 
-        if hasattr(self.options, 'languages'):
-            languages = self.options.languages
-        else:
-            languages = 'all'
+        languages = self.options.languages
 
         self.strip_languages(languages)
 
         _logger.info("Installing odoo")
 
-        target = (
-            self.options.target
-            if hasattr(self.options, 'target') and self.options.target
-            else None
-        )
-
-        upgrade = (
-            self.options.upgrade
-            if hasattr(self.options, 'upgrade') and self.options.upgrade
-            else False
-        )
+        target = self.options.target
+        upgrade = self.options.upgrade
 
         args = pip_command(target=target, upgrade=upgrade)
 
@@ -282,45 +270,3 @@ class OfficialRelease(OdooSource):
 
     def install(self):
         super().install()
-#
-#
-#   def setup_odoo_from_git(repo, ref, version, options=None):
-#
-#       if hasattr(options, 'cache'):
-#           cache = options.cache
-#       else:
-#           cache = None
-#
-#       installer = GitRelease(
-#           version,
-#           repo,
-#           ref,
-#           options=options,
-#           cache=cache
-#       )
-#
-#       with installer:
-#           if installer.need_update():
-#               installer.fetch()
-#               installer.checkout()
-#               installer.install()
-#
-#
-#   def setup_odoo_release(version, release, options=None):
-#       if hasattr(options, 'cache'):
-#           cache = options.cache
-#       else:
-#           cache = None
-#
-#       installer = OfficialRelease(
-#           version,
-#           release,
-#           options=options,
-#           cache=cache
-#       )
-#
-#       with installer:
-#           if installer.need_update():
-#               installer.fetch()
-#               installer.checkout()
-#               installer.install()

--- a/odoo_tools/configuration/odoo.py
+++ b/odoo_tools/configuration/odoo.py
@@ -1,3 +1,4 @@
+import sys
 from odoo_tools.compat import Path
 from ..configuration.git import checkout_repo
 from .misc import (
@@ -128,7 +129,12 @@ class OdooSource(object):
 
         _logger.info("Installing odoo")
 
-        args = ['python', '-m', 'pip', 'install']
+        args = [
+            sys.executable,
+            '-m',
+            'pip',
+            'install'
+        ]
 
         if hasattr(self.options, 'upgrade') and self.options.upgrade:
             args.append('-U')

--- a/odoo_tools/configuration/pip.py
+++ b/odoo_tools/configuration/pip.py
@@ -1,0 +1,31 @@
+import sys
+
+
+def pip_command(user=None, target=None, upgrade=False):
+    base_install_args = [
+        sys.executable,
+        '-m',
+        'pip',
+        'install',
+    ]
+
+    args = []
+    if user is True:
+        args.append('--user')
+
+    if target is not None:
+        python_version = (
+            f"{sys.version_info.major}.{sys.version_info.minor}"
+        )
+        args += [
+            "--target", str(target),
+            "--implementation", "cp",
+            "--python", python_version,
+            # "--only-binary", ":all:"
+            "--no-deps",
+        ]
+
+    if upgrade:
+        args.append('-U')
+
+    return base_install_args + args

--- a/odoo_tools/docker/user_entrypoint.py
+++ b/odoo_tools/docker/user_entrypoint.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 import time
 import os
@@ -7,6 +8,7 @@ import logging
 
 from ..utils import random_string
 from ..compat import pipe, Path
+from ..configuration.pip import pip_command
 
 
 _logger = logging.getLogger(__name__)
@@ -101,12 +103,11 @@ def install_python_dependencies(env):
             _logger.info("Requirements:\n%s", data)
             fout.write(data)
 
-        retcode = pipe([
-            "pip",
-            "install",
-            "--user",
+        args = pip_command(user=True) + [
             "-r", str(file_path)
-        ])
+        ]
+
+        retcode = pipe(args)
 
     if env.context.strict_mode and retcode != 0:
         raise Exception("Failed to install pip dependencies")

--- a/odoo_tools/exceptions.py
+++ b/odoo_tools/exceptions.py
@@ -12,3 +12,6 @@ class ArgumentError(Exception):
 
 class NoConfigError(Exception):
     pass
+
+class FileParserMissingError(Exception):
+    pass

--- a/odoo_tools/modules/search.py
+++ b/odoo_tools/modules/search.py
@@ -398,7 +398,9 @@ def find_addons_paths(paths, options=False):
         for ep in pkg_resources.iter_entry_points(group=entry_point):
             functor = ep.load()
             new_paths = functor()
-            paths |= new_paths
+
+            if new_paths:
+                paths |= new_paths
 
     modules = find_modules_paths(
         paths,

--- a/odoo_tools/packages/map-16.toml
+++ b/odoo_tools/packages/map-16.toml
@@ -1,0 +1,1 @@
+ldap = "python-ldap"

--- a/odoo_tools/patch.py
+++ b/odoo_tools/patch.py
@@ -1,0 +1,98 @@
+import sys
+import weakref
+import gc
+
+
+def used_in_modules(check_value):
+    val_id = id(check_value)
+
+    modules = [
+        (name, module)
+        for name, module in sys.modules.items()
+    ]
+
+    for mod_name, module in modules:
+        attributes = [
+            (name, value)
+            for name, value in module.__dict__.items()
+        ]
+
+        for name, value in attributes:
+            if id(value) == val_id:
+                yield mod_name, module, name
+
+
+def replace_modules_value(value, replacement):
+    for name, module, attribute in used_in_modules(value):
+        setattr(module, attribute, replacement)
+
+
+def unload_modules(module_name, unload_submodules=True):
+    """
+    Remove the module or the module and its submodules from sys.modules
+
+    Unloading a module can be used to remove all traces of a module in
+    sys.modules and all the refference to the modules including circular
+    references.
+
+    Odoo can import odoo.models from odoo and import odoo from models. In
+    that case, python isn't smart enough to garbage collect the reference
+    island. This function can find all references and will attempt to
+    remove everything that it can in hope that this will be enough
+    for the gc to clean up the rest.
+
+    For example this:
+
+    .. code:: python
+
+        import odoo
+        unload_modules('odoo') # this will remove all odoo.* from sys
+        # here odoo shouldn't reference anything
+
+    .. caution::
+
+        When removing a module from sys.modules it doesn't guarantee
+        that all references of the modules are gone. It simply guarantee
+        that the module can be reimported.
+
+        Dangling references can prevent imported modules from being garbage
+        collected or said differently this will create a memory leak.
+    """
+    submodule_filter = "{}.".format(module_name)
+
+    modules = [
+        mod
+        for mod in sys.modules.keys()
+        if (
+            mod == module_name or
+            (unload_submodules and mod.startswith(submodule_filter))
+        )
+    ]
+
+    weakrefs = [
+        weakref.ref(sys.modules[mod])
+        for mod in modules
+    ]
+
+    for mod in modules:
+        del sys.modules[mod]
+
+    for ref in weakrefs:
+        if ref() is None:
+            # It's already cleaned
+            continue
+
+        referrers = gc.get_referrers(ref())
+        id_ref = id(ref())
+        for refferer in referrers:
+            if isinstance(refferer, dict):
+                to_remove = [
+                    key
+                    for key, val in refferer.items()
+                    if id(val) == id_ref
+                ]
+                for key in to_remove:
+                    del refferer[key]
+
+        if ref() is not None:
+            print(f"Couldn't completely unload {ref()} with {len(gc.get_referrers(ref()))}")

--- a/odoo_tools/requirements/requirements-15.0.txt
+++ b/odoo_tools/requirements/requirements-15.0.txt
@@ -16,7 +16,7 @@ MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19
 passlib==1.7.3 # min version = 1.7.2 (Focal with security backports)
-Pillow==9.0.1  # min version = 7.0.0 (Focal with security backports)
+Pillow>=7.0  # min version = 7.0.0 (Focal with security backports)
 polib==1.1.0
 psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
 psycopg2==2.8.5; sys_platform == 'win32'
@@ -24,7 +24,7 @@ psycopg2 >=2.7.7; sys_platform != 'win32'
 pydot==1.4.1
 pyopenssl>=21.0.0
 cryptography
-PyPDF2==1.26.0
+PyPDF2==1.26,<2.0
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.4
 python-dateutil==2.7.3
@@ -33,7 +33,7 @@ python-stdnum==1.13
 pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
+reportlab>=3.5.54 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
 requests>=2.22.0, <3
 urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1

--- a/odoo_tools/requirements/requirements-16.0.txt
+++ b/odoo_tools/requirements/requirements-16.0.txt
@@ -11,30 +11,30 @@ gevent>=20.9.0 ; python_version >= '3.8'
 greenlet>=0.4.10
 idna==2.8
 Jinja2==2.11.3 # min version = 2.10.1 (Focal - with security backports)
-libsass==0.18.0
-lxml==4.6.5 # min version = 4.5.0 (Focal - with security backports)
+libsass>=0.18,<=0.21
+lxml>=4.5.0 # min version = 4.5.0 (Focal - with security backports)
 MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse ==0.19; python_version <= '3.9'
 ofxparse >=0.21; python_version > '3.9'  # (Jammy)
 passlib==1.7.3 # min version = 1.7.2 (Focal with security backports)
-Pillow==9.0.1  # min version = 7.0.0 (Focal with security backports)
+Pillow>=7.0  # min version = 7.0.0 (Focal with security backports)
 polib==1.1.0
-psutil==5.6.7 # min version = 5.5.1 (Focal with security backports)
+psutil>=5.5.1 # min version = 5.5.1 (Focal with security backports)
 psycopg2==2.8.5; sys_platform == 'win32'
 psycopg2 >=2.7.7; sys_platform != 'win32'
 pydot==1.4.1
 pyopenssl>=21.0.0
-PyPDF2==1.26.0
+PyPDF2>=1.26,<2.0
 pypiwin32 ; sys_platform == 'win32'
 pyserial==3.4
 python-dateutil==2.7.3
-python-ldap==3.4.0 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
+python-ldap>=3.2 ; sys_platform != 'win32'  # min version = 3.2.0 (Focal with security backports)
 python-stdnum==1.13
 pytz==2019.3
 pyusb==1.0.2
 qrcode==6.1
-reportlab==3.5.59 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
+reportlab>=3.5.54 # version < 3.5.54 are not compatible with Pillow 8.1.2 and 3.5.59 is bullseye
 requests>=2.22.0, <3
 urllib3==1.26.5 # indirect / min version = 1.25.8 (Focal with security backports)
 vobject==0.9.6.1

--- a/odoo_tools/utilities/loaders.py
+++ b/odoo_tools/utilities/loaders.py
@@ -1,0 +1,37 @@
+from ..exceptions import FileParserMissingError
+
+
+class FileLoader(object):
+    def __init__(self):
+        self.parsers = {}
+
+    def load_file(self, path, default_loader=None):
+        loaders = self.get_loaders(path, default_loader)
+
+        with path.open('r') as fin:
+            data = fin.read()
+
+        for loader in loaders:
+            data = loader(data)
+
+        return data
+
+    def get_loaders(self, path, default_loader=None):
+        suffixes = path.suffixes
+
+        loaders = []
+
+        if not suffixes and not default_loader:
+            return loaders
+
+        suffixes.reverse()
+
+        for suffix in suffixes:
+            try:
+                loaders.append(self.parsers[suffix])
+            except KeyError:
+                raise FileParserMissingError(
+                    "Cannot parse a file with the type {}".format(suffix)
+                )
+
+        return loaders

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="odoo-tools",
-    version="0.1.3.1",
+    version="0.1.4",
     author="Loïc Faure-Lacroix <lamerstar@gmail.com>",
     author_email="lamerstar@gmail.com",
     description="Odoo Tools",

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,24 @@ setuptools.setup(
     python_requires='>=3.6',
     entry_points={
         "console_scripts": [
-            "odootools = odoo_tools.cli.odot:command"
+            "odootools = odoo_tools.cli.odot:command",
         ],
+        "odootools.registry": [
+            "registry = odoo_tools.cli.registry:registry",
+        ],
+        "odootools.command": [
+            "module = odoo_tools.cli.click.module:module",
+            "addons_paths = odoo_tools.cli.click.path:addons_paths",
+            "config = odoo_tools.cli.click.config:config",
+            "entrypoint = odoo_tools.cli.click.entrypoint:entrypoint",
+            "shell = odoo_tools.cli.click.shell:shell",
+            "manage = odoo_tools.cli.click.manage:manage",
+            "service = odoo_tools.cli.click.services:service",
+            "platform = odoo_tools.cli.click.platform:platform",
+            "user = odoo_tools.cli.click.users:user",
+            "db = odoo_tools.cli.click.db:db",
+            "gen = odoo_tools.cli.click.gen:gen",
+        ]
     },
     package_data={
         "odoo_tools": [

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
         "packaging",
         "lxml",
         "docutils",
+        "distro",
         "polib",
         "six>=1.12.0",
         "cryptography",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -94,7 +94,7 @@ def odoo_release():
 
     odoo_version = "{}.0".format(os.environ['TEST_ODOO'])
 
-    env.manage.install_odoo(odoo_version, release="20220624", opts=options)
+    env.manage.install_odoo(odoo_version, release="20221019", opts=options)
 
     try:
         yield env

--- a/tests/test_api_context.py
+++ b/tests/test_api_context.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+from pathlib import Path
+from mock import patch
+from odoo_tools.api.context import Context
+
+
+def test_context_default_odoorc(tmp_path):
+    new_env = {
+        "HOME": str(tmp_path)
+    }
+
+    with patch.dict(os.environ, new_env, clear=True):
+        ctx = Context()
+        assert ctx.default_odoorc() == Path.cwd() / 'odoo.cfg'
+
+    new_env = {
+        "HOME": str(tmp_path),
+    }
+
+    with patch.dict(os.environ, new_env, clear=True):
+        odoo_rc = tmp_path / '.odoorc'
+        with odoo_rc.open('w') as fout:
+            fout.write('')
+
+        ctx = Context()
+        assert ctx.default_odoorc() == odoo_rc
+
+    ctx = Context()
+    assert ctx.default_odoorc() == Path.cwd() / 'odoo.cfg'
+    assert ctx.odoo_rc == Path.cwd() / 'odoo.cfg'

--- a/tests/test_api_objects.py
+++ b/tests/test_api_objects.py
@@ -2,6 +2,33 @@ import pytest
 from pathlib import Path
 from odoo_tools.api.objects import CompanySpec, Manifest
 
+fake_files = {
+    "__init__.py": """
+from . import models
+from . import controllers
+""",
+    "models/__init__.py": """
+from . import sale_obj
+""",
+    "models/sale_obj": """
+from odoo import models
+
+class MyObj(models.Model):
+    _name = "my.obj"
+""",
+    "controllers/__init__.py": """
+from . import main
+""",
+    "controllers/main.py": """
+from odoo.http import Controller
+
+class MyController(Controller):
+    @http.route()
+    def whoa():
+        return ""
+"""
+    }
+
 
 def test_company_spec():
     company = CompanySpec(country_code='CA')
@@ -111,3 +138,40 @@ def test_invalid_manifest(tmp_path):
 
     with pytest.raises(SyntaxError):
         manifest = Manifest.from_path(manifest.path)
+
+
+def test_manifest_checksum(tmp_path):
+    module_path = tmp_path / 'sup'
+
+    manifest = Manifest(tmp_path / 'sup')
+
+    manifest.set_attribute(
+        ['external_dependencies', 'python'],
+        ['web', 'base', 'fun']
+    )
+
+    manifest.save()
+
+    main_controller = module_path / 'controllers/main.py'
+    manifest_file = module_path / '__manifest__.py'
+
+    # Add file to generate valid module
+    for filename, data in fake_files.items():
+        file_path = module_path / filename
+        file_path.parent.mkdir(exist_ok=True, parents=True)
+        with file_path.open('w') as fout:
+            fout.write(data)
+    checksum = manifest.checksum()
+    assert checksum.hexdigest() == "01f34218933d0cc173a1cac18ca6c96779901de9"
+
+    # Ensure that sub file modified changes checksum
+    with main_controller.open('w') as fout:
+        fout.write("import odoo\n")
+    checksum = manifest.checksum()
+    assert checksum.hexdigest() == "006236cde58f9110ccfc1aea264bee2da8c3fc1f"
+
+    # Check that manifest is part of the file
+    with manifest_file.open('w') as fout:
+        fout.write('{}')
+    checksum = manifest.checksum()
+    assert checksum.hexdigest() == "f7daa17811c84315adf726ad7e6a026943b48a22"

--- a/tests/test_api_services.py
+++ b/tests/test_api_services.py
@@ -1,0 +1,68 @@
+import json
+from mock import patch
+from odoo_tools.odoo import Environment
+
+
+def test_load_service(tmp_path):
+    env = Environment()
+
+    service_path = tmp_path / 'services.json'
+    service_file = {
+        "services": [
+            {
+                "name": "odoo",
+                "odoo": {
+                    "version": "15.0",
+                },
+                "addons": [
+                    {
+                        "url": "git@github.com:llacroix/odoo-tools.git",
+                    }
+                ]
+            },
+            {
+                "name": "dev",
+                "inherit": "odoo",
+                "addons": [
+                    {
+                        "url": "git@github.com:llacroix/odoo-tools-rest.git",
+                    }
+                ]
+            }
+        ]
+    }
+
+    with service_path.open("w") as fout:
+        fout.write(
+            json.dumps(service_file)
+        )
+
+    services = env.services.get_services(service_path)
+
+    assert 'odoo' in services.services
+    assert 'dev' in services.services
+
+    prod = services.services['odoo']
+    dev = services.services['dev'].resolved
+
+    assert len(prod.addons) == 1
+    assert len(dev.addons) == 2
+
+    with patch('odoo_tools.api.services.fetch_addons') as fa,\
+         patch('odoo_tools.api.services.checkout_repo') as cr,\
+         patch('odoo_tools.api.services.ZipFile') as zp:
+        fa.side_effect = [('p', 'a'), ('b', 'c')]
+
+        res = env.services.checkout(
+            dev,
+            str(tmp_path / 'build')
+        )
+
+        assert res == ['a', 'c']
+
+        fa.side_effect = [('p', 'a'), ('b', 'c')]
+
+        env.services.package(
+            dev,
+            str(tmp_path / 'package')
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,20 +1,12 @@
 import toml
 import json
-import pytest
 from unittest.mock import patch, MagicMock, PropertyMock
-from click.testing import CliRunner
 
-import os
 from odoo_tools.cli.odot import command
 from odoo_tools.api.management import ManagementApi
 from odoo_tools.api.db import DbApi
 from odoo_tools.api.environment import Environment
 # from odoo_tools.cli import fetch_addons, copy_addons
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 def test_command(runner):
@@ -761,7 +753,12 @@ def test_manage_install_odoo(runner, tmp_path):
             release=None,
             ref="15.0",
             repo='https://github.com/odoo/odoo.git',
-            opts={'languages': 'all'}
+            opts={
+                'languages': 'all',
+                'upgrade': False,
+                'target': None,
+                'cache': None
+            }
         )
 
         mock_method.reset_mock()
@@ -817,6 +814,9 @@ def test_manage_install_odoo(runner, tmp_path):
             repo='https://github.com/odoo/odoo.git',
             opts={
                 'languages': 'all',
+                'cache': None,
+                'target': None,
+                'upgrade': False
             }
         )
 
@@ -842,6 +842,9 @@ def test_manage_install_odoo(runner, tmp_path):
             repo='https://github.com/odoo/odoo.git',
             opts={
                 'languages': 'all',
+                'cache': None,
+                'target': None,
+                'upgrade': False,
             }
         )
 
@@ -1274,3 +1277,15 @@ def test_remove_user(runner):
         assert result.exception is None
         users_rs.toggle_active.assert_not_called()
         users_rs.unlink.assert_not_called()
+
+
+def test_gen(runner):
+    result = runner.invoke(
+        command,
+        [
+            'gen',
+            'info',
+        ]
+    )
+
+    assert result.exception is None

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,100 @@
+import pytest
+import click
+from mock import patch, call, MagicMock
+
+from odoo_tools.cli.registry import CommandRegistry
+
+
+def test_empty_registry():
+    registry = CommandRegistry()
+
+    with pytest.raises(KeyError):
+        registry.get('gen')
+
+    assert len(registry.groups) == 0
+
+
+def test_register_command(runner):
+
+    @click.group()
+    def main():
+        pass
+
+    @click.group()
+    def my_group():
+        pass
+
+    @click.command()
+    def my_cmd():
+        print('my-cmd1')
+
+    @click.command()
+    def my_cmd2():
+        print('my-cmd2')
+
+    registry = CommandRegistry()
+
+    ep = MagicMock()
+    ep.load.return_value = my_group
+    ep.name = 'my_group'
+
+    ep2 = MagicMock()
+    ep2.load.return_value = my_cmd
+    ep2.name = 'my_group'
+
+    with patch('odoo_tools.cli.registry.iter_entry_points') as it:
+        it.side_effect = [[ep], [ep2]]
+        registry.register_commands()
+
+    assert len(registry.groups) == 1
+
+    registry.set_main(main)
+
+    my_group2 = registry.get('my_group')
+    assert my_group == my_group2
+
+    registry.load()
+    assert len(registry.loaded) == 1
+
+    registry.load()
+    assert len(registry.loaded) == 1
+
+    result = runner.invoke(
+        main,
+        [
+            'my-group',
+            'my-cmd',
+        ]
+    )
+
+    assert result.exception is None
+    assert result.output == 'my-cmd1\n'
+
+    result = runner.invoke(
+        main,
+        [
+            'my-group',
+            'my-cmd2',
+        ]
+    )
+
+    assert isinstance(result.exception, SystemExit)
+
+    ep3 = MagicMock()
+    ep3.load.return_value = my_cmd2
+    ep3.name = 'my_group'
+
+    with patch('odoo_tools.cli.registry.iter_entry_points') as it:
+        it.side_effect = [[], [ep3]]
+        registry.register_commands()
+
+    result = runner.invoke(
+        main,
+        [
+            'my-group',
+            'my-cmd2',
+        ]
+    )
+
+    assert result.exception is None
+    assert result.output == 'my-cmd2\n'

--- a/tests/test_manage.py
+++ b/tests/test_manage.py
@@ -38,3 +38,13 @@ def test_management_config():
 def test_management_options():
     env = Environment()
     assert isinstance(env.manage.options, dict)
+
+
+def test_management_native_packages():
+    env = Environment()
+    default_packages = env.manage.native_packages("default")
+    assert len(default_packages) > 0
+
+    packages = env.manage.native_packages()
+    assert len(packages) > 0
+    assert packages != default_packages

--- a/tests/test_odoo_git.py
+++ b/tests/test_odoo_git.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import pytest
+from collections import defaultdict
+from mock import patch, MagicMock
+from odoo_tools.api.objects import Manifest
+
+from odoo_tools.entrypoints import entrypoint
+from odoo_tools import entrypoints
+from odoo_tools.docker.user_entrypoint import (
+    setup_env_config
+)
+
+
+@pytest.mark.skipif(
+    'TEST_ODOO' not in os.environ,
+    reason="Testing Odoo is disabled"
+)
+def test_check_odoo(odoo_env):
+    odoo_env.check_odoo()
+
+
+@pytest.mark.skipif(
+    'TEST_ODOO' not in os.environ,
+    reason="Testing Odoo is disabled"
+)
+def test_get_odoo_addons(odoo_env):
+    assert len(odoo_env.addons_paths()) == 1
+
+    bus_module = odoo_env.modules.get('bus')
+
+    assert bus_module.technical_name == 'bus'
+
+    from odoo.tools import config
+
+    assert config == odoo_env.odoo_config()
+
+
+@pytest.mark.skipif(
+    'TEST_ODOO' not in os.environ,
+    reason="Testing Odoo is disabled"
+)
+def test_env_options(odoo_env):
+    from odoo.tools import config
+
+    config['workers'] = 0
+
+    vals = dict(
+        ODOO_LOAD="web,base,fun",
+        ODOO_WORKERS="3",
+        ODOO_DATABASE="fun"
+    )
+
+    with patch.dict(os.environ, vals, clear=True):
+        conf = odoo_env.env_options()
+
+        with odoo_env.config() as conf1:
+            conf1.set('queue', 'channel', 1)
+
+        assert conf['workers'] == "3"
+        assert conf['server_wide_modules'] == "web,base,fun"
+        assert conf['db_name'] == 'fun'
+
+        assert config.get('server_wide_modules') == 'base,web'
+        assert config.get('db_name') is False
+        assert config.get('workers') == 0
+        assert config.misc.get('queue') is None
+
+        odoo_env.sync_options()
+
+        assert config.get('server_wide_modules') == 'web,base,fun'
+        assert config.get('db_name') == "fun"
+        assert config.get('workers') == "3"
+        assert config.misc['queue']['channel'] == '1'
+
+
+@pytest.mark.skipif(
+    'TEST_ODOO' not in os.environ,
+    reason="Requires odoo to fetch env_options"
+)
+def test_set_env_config(odoo_env, tmp_path):
+    new_environ = {}
+
+    with patch.dict(os.environ, new_environ, clear=True):
+        setup_env_config(odoo_env)
+
+    with odoo_env.config():
+        assert odoo_env.get_config('db_host') is False
+
+    new_environ = {
+        "ODOO_DATABASE": "db1",
+        "ODOO_LOAD": "web,base,kankan",
+        "ODOO_WITHOUT_DEMO": "web",
+    }
+
+    with patch.dict(os.environ, new_environ, clear=True):
+        setup_env_config(odoo_env)
+
+    with odoo_env.config():
+        assert odoo_env.get_config('db_name') == 'db1'
+        assert odoo_env.get_config('server_wide_modules') == 'web,base,kankan'
+        assert odoo_env.get_config('without_demo') == 'web'

--- a/tests/test_odoo_release.py
+++ b/tests/test_odoo_release.py
@@ -2,76 +2,11 @@ import os
 import sys
 import pytest
 from collections import defaultdict
-from mock import patch, MagicMock
-from odoo_tools.api.objects import Manifest
+from mock import MagicMock
 
 from odoo_tools.entrypoints import entrypoint
 from odoo_tools import entrypoints
-from odoo_tools.docker.user_entrypoint import (
-    setup_env_config
-)
-
-
-@pytest.mark.skipif(
-    'TEST_ODOO' not in os.environ,
-    reason="Testing Odoo is disabled"
-)
-def test_check_odoo(odoo_env):
-    odoo_env.check_odoo()
-
-
-@pytest.mark.skipif(
-    'TEST_ODOO' not in os.environ,
-    reason="Testing Odoo is disabled"
-)
-def test_get_odoo_addons(odoo_env):
-    assert len(odoo_env.addons_paths()) == 1
-
-    bus_module = odoo_env.modules.get('bus')
-
-    assert bus_module.technical_name == 'bus'
-
-    from odoo.tools import config
-
-    assert config == odoo_env.odoo_config()
-
-
-@pytest.mark.skipif(
-    'TEST_ODOO' not in os.environ,
-    reason="Testing Odoo is disabled"
-)
-def test_env_options(odoo_env):
-    from odoo.tools import config
-
-    config['workers'] = 0
-
-    vals = dict(
-        ODOO_LOAD="web,base,fun",
-        ODOO_WORKERS="3",
-        ODOO_DATABASE="fun"
-    )
-
-    with patch.dict(os.environ, vals):
-        conf = odoo_env.env_options()
-
-        with odoo_env.config() as conf1:
-            conf1.set('queue', 'channel', 1)
-
-        assert conf['workers'] == "3"
-        assert conf['server_wide_modules'] == "web,base,fun"
-        assert conf['db_name'] == 'fun'
-
-        assert config.get('server_wide_modules') == 'base,web'
-        assert config.get('db_name') is False
-        assert config.get('workers') == 0
-        assert config.misc.get('queue') is None
-
-        odoo_env.sync_options()
-
-        assert config.get('server_wide_modules') == 'web,base,fun'
-        assert config.get('db_name') == "fun"
-        assert config.get('workers') == "3"
-        assert config.misc['queue']['channel'] == '1'
+from odoo_tools.api.objects import Manifest
 
 
 @pytest.mark.skipif(
@@ -159,35 +94,7 @@ def test_init_db(odoo_release):
     'TEST_ODOO' not in os.environ,
     reason="Requires odoo to fetch env_options"
 )
-def test_set_env_config(odoo_env, tmp_path):
-    new_environ = {}
-
-    with patch.dict(os.environ, new_environ, clear=True):
-        setup_env_config(odoo_env)
-
-    with odoo_env.config():
-        assert odoo_env.get_config('db_host') is False
-
-    new_environ = {
-        "ODOO_DATABASE": "db1",
-        "ODOO_LOAD": "web,base,kankan",
-        "ODOO_WITHOUT_DEMO": "web",
-    }
-
-    with patch.dict(os.environ, new_environ, clear=True):
-        setup_env_config(odoo_env)
-
-    with odoo_env.config():
-        assert odoo_env.get_config('db_name') == 'db1'
-        assert odoo_env.get_config('server_wide_modules') == 'web,base,kankan'
-        assert odoo_env.get_config('without_demo') == 'web'
-
-
-@pytest.mark.skipif(
-    'TEST_ODOO' not in os.environ,
-    reason="Requires odoo to fetch env_options"
-)
-def test_export_translations(tmp_path):
+def test_export_translations(odoo_release, tmp_path):
     db = MagicMock()
 
     db.export_translation_terms.return_value = [


### PR DESCRIPTION
Changes:

- Service has its own API now instead of being just a command line
- The CLI part can be extended with entrypoints definition. Some part of this library may end up in different python package to make updating each individual part less cumbersome without having to worry too much about the main odootools package.
- A gen command line has been added to allow generating things like new odoo modules. This will get extended by other python packages like "odoo-tools-rest" which is likely to be renamed to something like odoo-tools-openapi" because that's really what this is.

Fixes:
- Try to read config file only once. The config is kept in memory without requiring to be reloaded all the time.
- Prevent crash from improper entrypoints
- some fixed to "docker entrypoints"

Fixing the docker entrypoint makes it possible to release an improved version of odoo-docker image. After releasing 0.1.4, it will become possible to update the entrypoints to use odoo-tools and potentially add a new package that will be used to generate docker images. The docker images generated by odoo-tools will itself use odoo-tools to configure the odoo environment. 